### PR TITLE
fix(tui-remote): preserve URL prefix when deriving command URL

### DIFF
--- a/agent/tui_state_source.py
+++ b/agent/tui_state_source.py
@@ -185,10 +185,19 @@ class WebSocketRemoteStateSource(StateSource):
         if command_token is None and token is not None:
             command_token = token
         self.url = url
-        # Derive default command URL from the state URL (same host, /ws/command).
+        # Derive default command URL from the state URL by swapping the last
+        # path segment from /state → /command. Preserves any prefix —
+        # critical for the /ws/agent/* path where the old hardcoded
+        # /ws/command would land on the relay container (different auth
+        # token) and return 403 to a TUI carrying the daemon-proxy token.
         if command_url is None:
             parsed = urlparse(url)
-            cmd_parsed = parsed._replace(path="/ws/command", query="", fragment="")
+            state_path = parsed.path
+            if state_path.endswith("/state"):
+                cmd_path = state_path[: -len("/state")] + "/command"
+            else:
+                cmd_path = "/ws/command"  # legacy / non-standard URLs
+            cmd_parsed = parsed._replace(path=cmd_path, query="", fragment="")
             command_url = urlunparse(cmd_parsed)
         self.command_url = command_url
         # Token resolution order:


### PR DESCRIPTION
## Summary
- Fix v9.1.0 regression: every TUI write returned HTTP 403 against the new `/ws/agent/*` gate.
- The state URL `wss://dj.treta.life/ws/agent/state` was getting paired with a hardcoded `/ws/command` command URL — landing on the relay container (port 8080), which validates a different token than the nginx `/ws/agent/*` proxy.

## Why two bugs were the same root cause
Both symptoms traced back to one broken URL:
- `DJ Treta: server rejected WebSocket connection: HTTP 403` on every talk attempt.
- Both deck panels rendering the same track title — the deck card falls back to `state.current_track` (singular, active-deck-only) when its per-deck `mixxx_proxy(/api/deck/N/track_info)` call fails. With 403 on every call, both decks rendered the active deck's title.

Verified via Mixxx API at the time of report: `deck1=ARTBAT - Horizon`, `deck2=Ben Böhmer - Desolate` — distinct, so the duplicate display was purely client-side.

## The fix
Derive the command path from the state path by swapping the trailing `/state` → `/command`, instead of hardcoding `/ws/command`:
- `/ws/state` → `/ws/command` (legacy / relay) — still works
- `/ws/agent/state` → `/ws/agent/command` (daemon proxy) — now works

## Test plan
- [ ] `djtreta --remote` launches against `wss://dj.treta.life/ws/agent/state`
- [ ] Type into the input box — agent responds (no 403)
- [ ] Two decks loaded with different tracks → two distinct titles render
- [ ] Local `djtreta` (no `--remote`) still talks to local daemon

## Followup
This pairs with v9.1.0; suggest tagging `v9.1.1` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)