### PR TITLE
fix(install): swap NUL transport for shlex-quoted KEY=value lines

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -509,32 +509,47 @@ operator_validate() {
 # Python's urllib for URL parsing. Operator can also bypass URL
 # embedding entirely with --stream-user / --stream-pass.
 operator_parse_stream_url() {
-  local parsed
-  parsed=$(STREAM_URL="$STREAM_URL" python3 - <<'PY' || true
-import os, sys, urllib.parse as up
+  # Transport gotcha: bash command substitution `$(...)` STRIPS NUL bytes
+  # from the output (documented bash behavior, all versions). An earlier
+  # attempt at NUL-separated transport silently broke — every operator
+  # install without --stream-pass would die at the empty-pass check.
+  #
+  # We instead emit shell-safe `KEY=value` lines from Python (using
+  # shlex.quote) and `eval` the safe subset. Python's exit code is
+  # captured properly so a parse failure surfaces as a die() instead of
+  # silent empty output.
+  local exports rc
+  exports=$(STREAM_URL="$STREAM_URL" python3 - <<'PY'
+import os, sys, shlex, urllib.parse as up
 url = os.environ.get("STREAM_URL", "")
 if not url.startswith("icecast://"):
-    print("ERROR: scheme must be icecast://", file=sys.stderr); sys.exit(1)
-p = up.urlparse("http://" + url[len("icecast://"):])
+    print("scheme must be icecast://", file=sys.stderr); sys.exit(1)
+try:
+    p = up.urlparse("http://" + url[len("icecast://"):])
+except ValueError as e:
+    print(f"unparseable: {e}", file=sys.stderr); sys.exit(1)
 host = p.hostname or ""
 port = p.port or 8000
 mount = p.path or ""
 user = up.unquote(p.username or "") if p.username else ""
 password = up.unquote(p.password or "") if p.password else ""
 if not host or not mount or mount == "/":
-    print("ERROR: need host + /mount", file=sys.stderr); sys.exit(1)
-# NUL-separate so the shell can split unambiguously even if values
-# contain whitespace or shell metacharacters.
-sys.stdout.buffer.write(b"\0".join(s.encode() for s in (user, password, host, str(port), mount)))
+    print("need host + /mount", file=sys.stderr); sys.exit(1)
+# Newline-separated KEY=quoted-value pairs. shlex.quote handles every
+# special char correctly for `eval` consumption. No NUL bytes.
+for k, v in (("STREAM_USER", user), ("STREAM_PASS", password),
+             ("STREAM_HOST", host), ("STREAM_PORT", str(port)),
+             ("STREAM_MOUNT", mount)):
+    print(f"{k}={shlex.quote(v)}")
 PY
-)
-  if [ -z "$parsed" ]; then
+) ; rc=$?
+  if [ "$rc" -ne 0 ] || [ -z "$exports" ]; then
     die "Invalid --stream-url: '$STREAM_URL' (want icecast://user:pass@host:port/mount)"
   fi
-  IFS=$'\0' read -r STREAM_USER STREAM_PASS STREAM_HOST STREAM_PORT STREAM_MOUNT <<<"$parsed"
+  eval "$exports"
 
   # --stream-user / --stream-pass override anything embedded in the URL.
-  # Recommended for operators with credentials containing reserved chars.
+  # Recommended path for operators with credentials containing reserved chars.
   [ -n "$STREAM_USER_FLAG" ] && STREAM_USER="$STREAM_USER_FLAG"
   [ -n "$STREAM_PASS_FLAG" ] && STREAM_PASS="$STREAM_PASS_FLAG"
 


### PR DESCRIPTION
## Summary
Fixes a blocking bug in PR #83 caught by post-merge review.

Bash command substitution `\$(...)` silently strips NUL bytes (documented behavior, all bash versions; bash 5 prints a warning to stderr). The NUL-separated transport in 2094cb6 made every operator install **without `--stream-pass`** die at the empty-pass check — `IFS=\$'\0' read` saw the entire blob concatenated into `STREAM_USER`, leaving `STREAM_PASS` / `STREAM_HOST` / `STREAM_PORT` / `STREAM_MOUNT` empty.

## Fix
- Transport is now newline-separated `KEY=\$(shlex.quote(value))` pairs that bash `eval`s. No NUL bytes, no shell-meta confusion.
- Capture Python's exit code with `rc=\$?` instead of swallowing with `|| true`. Parse failures now surface as a clean `die()`.

## Test
Verified locally with three cases:
- `icecast://source:secret@host:8000/live` → all 5 fields parse ✓
- `icecast://source:p%40ss%3Awo%7Crd@host:8000/live` → password decoded to `p@ss:wo|rd` ✓
- `not-a-stream-url` → rc=1, empty exports, `die()` fires with clear message ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)