### PR TITLE
fix(transitions): runtime overshoot guard + stale-schedule detection + crossfade force-end

### DIFF
--- a/agent/tools/transitions.py
+++ b/agent/tools/transitions.py
@@ -217,7 +217,39 @@ def do_transition(to_deck: int, duration: int = 60, bpm_after: str = "keep", gli
 
     # Mixxx C++ S-curve transition (20fps, smooth)
     _mixxx_post("/api/transition", {"deck": to_deck, "duration": duration})
-    _time.sleep(duration + 2)
+
+    # ── Patch C: crossfade end-safety belt ────────────────────────────
+    # Replace blind _time.sleep(duration + 2) with a watchdog poll. If
+    # the OUTGOING deck runs out mid-fade (track shorter than the fade,
+    # or the schedule ran late), we detect rem<0.5s, force xf to dest
+    # immediately, and break — no more cut-out audible to the listener.
+    deadline = _time.monotonic() + duration + 2
+    forced_end = False
+    while _time.monotonic() < deadline:
+        try:
+            st = _mixxx_get("/api/status") or {}
+            d_out = st.get(f"deck{out_deck}", {})
+            rem_out = float(d_out.get("remaining_seconds", 0) or 0)
+            playing_out = bool(d_out.get("playing", False))
+        except Exception:
+            rem_out = 999.0
+            playing_out = True
+        if (playing_out and rem_out < 0.5) or (not playing_out and rem_out <= 0):
+            # Outgoing track is at the cliff — slam crossfader to dest.
+            xf_force = 0.0 if to_deck == 1 else 1.0
+            try:
+                _mixxx_post("/api/crossfade", {"position": xf_force})
+            except Exception:
+                pass
+            forced_end = True
+            log.warning(
+                f"[CROSSFADE-FORCE-END] outgoing deck {out_deck} hit end "
+                f"mid-fade (rem={rem_out:.2f}s, playing={playing_out}); "
+                f"forced crossfader to {xf_force}"
+            )
+            break
+        _time.sleep(0.5)
+
     # Make sure bass-restore has run even if duration math drifted.
     _mixxx_post("/api/eq", {"deck": to_deck, "lo": 1.0})
 
@@ -1274,6 +1306,17 @@ def schedule_transition(to_deck: int, at_position: int, technique: str = "crossf
         at_position = current_pos + 2  # start in 2 seconds
         delay = 2
 
+    # Capture the active track's file_path at scheduling time so the
+    # executor can detect a stale schedule (planner force-load between
+    # schedule and fire would leave at_position pointing at a track that
+    # no longer exists on the deck — Patch B / overshoot-safety).
+    active_track_path = ""
+    try:
+        _tinfo = _mixxx_get(f"/api/deck/{active_deck}/track_info") or {}
+        active_track_path = _tinfo.get("file_path", "") or ""
+    except Exception:
+        active_track_path = ""
+
     # Write schedule -- Python (_execute_scheduled_transition in main.py) picks this up
     scheduled = {
         "toDeck": to_deck,
@@ -1285,6 +1328,8 @@ def schedule_transition(to_deck: int, at_position: int, technique: str = "crossf
         "executesIn": round(delay),
         "bpmAfter": str(bpm_after),
         "glideDuration": max(5, min(60, glide_duration)),
+        "activeTrackPath": active_track_path,
+        "activeTrackDuration": track_duration,
     }
     runtime_path("scheduled-transition.json").write_text(
         json.dumps(scheduled, indent=2)

--- a/agent/transitions.py
+++ b/agent/transitions.py
@@ -14,6 +14,7 @@ class TransitionMixin:
     def _execute_scheduled_transition(self, sched: dict):
         """Python-side transition executor. Waits for track position, then executes.
         Runs in its own thread. Agent is FREE during this entire time."""
+        import httpx
         from .main import _get_status
         from .tools import do_transition, do_bass_swap, do_filter_sweep, do_hard_cut, do_echo_out, do_riser, do_dissolve
 
@@ -22,6 +23,7 @@ class TransitionMixin:
         technique = sched.get("technique", "crossfade")
         duration = sched.get("duration", 45)
         active_deck = sched.get("activeDeck", 1 if to_deck == 2 else 2)
+        scheduled_track_path = sched.get("activeTrackPath", "") or ""
 
         log.info(f"Transition scheduled: {technique} to deck {to_deck} at {at_position}s (waiting...)")
 
@@ -43,6 +45,54 @@ class TransitionMixin:
                 gap = at_position - current_pos
 
                 if gap <= 0:
+                    # ── Patch B: stale-schedule detection ─────────────────
+                    # If the active deck's track changed between scheduling
+                    # and fire-time (planner force-load is the common cause),
+                    # the at_position is meaningless against the new track.
+                    # Abort and ask planner to re-evaluate.
+                    if scheduled_track_path:
+                        try:
+                            tinfo = httpx.get(
+                                f"{self.config.mixxx.url}/api/deck/{active_deck}/track_info",
+                                timeout=2,
+                            ).json() or {}
+                            current_track_path = tinfo.get("file_path", "") or ""
+                        except Exception:
+                            current_track_path = ""
+                        if current_track_path and current_track_path != scheduled_track_path:
+                            log.warning(
+                                f"[STALE-SCHEDULE] active track changed from "
+                                f"{scheduled_track_path!r} to {current_track_path!r}, "
+                                f"aborting scheduled {technique} — planner will re-evaluate"
+                            )
+                            if hasattr(self, "session"):
+                                try:
+                                    self.session.replan_requested = True
+                                except Exception:
+                                    pass
+                            break
+
+                    # ── Patch A: fire-time overshoot guard ────────────────
+                    # Re-fetch fresh status; the duration we scheduled with
+                    # might no longer fit the active track (cold-load 0,
+                    # short track, late tail). Shorten if needed.
+                    try:
+                        d_now = status.get(f"deck{active_deck}", {})
+                        rem_now = float(d_now.get("remaining_seconds", 0) or 0)
+                    except Exception:
+                        rem_now = 0.0
+                    if rem_now > 0 and rem_now < duration + 5:
+                        new_duration = max(10, int(rem_now - 5))
+                        if new_duration < duration:
+                            log.warning(
+                                f"[OVERSHOOT-GUARD] track ends in {rem_now:.1f}s, "
+                                f"transition needs {duration}s — shortening to "
+                                f"{new_duration}s so the fade finishes before track end"
+                            )
+                            if hasattr(self, '_ws_broadcast'):
+                                self._ws_broadcast("log", {"text": f"[OVERSHOOT-GUARD] shortening {technique} {duration}s → {new_duration}s (rem={rem_now:.1f}s)"})
+                            duration = new_duration
+
                     # Time to execute — right on the mark
                     log.info(f"Executing {technique} to deck {to_deck} at {current_pos:.1f}s (target: {at_position}s)")
                     if hasattr(self, '_ws_broadcast'):


### PR DESCRIPTION
## Symptom
Track ran out mid-crossfade. DJ scheduled at_position=188 + duration=54s on a 212s track; xf still +0.60 when D1 hit rem=0. User heard cut-out.

## 3 patches (defense in depth)
**A — fire-time overshoot guard** (transitions.py:54): re-reads remaining_seconds at fire time; shortens duration to fit if track too short. Catches cold-load track_duration=0 race that bypassed scheduling-time clamp.

**B — stale-schedule detection** (transitions.py:1278 schedule + 30 executor): captures active track path at scheduling, re-checks at fire. If track changed (planner force-load, etc.), abort + replan_requested. No more firing wrong at_position on wrong track.

**C — crossfade force-end watchdog** (do_transition:219): polls outgoing rem each 0.5s during fade; if outgoing ends, force crossfader to dest immediately. Last-line defense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)