### PR TITLE
fix(billing): per-model cost grounded in the gateway's authoritative numbers

### DIFF
--- a/agent/adk_runner.py
+++ b/agent/adk_runner.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+import threading
 import time
 from pathlib import Path
 from .runtime_paths import runtime_path
@@ -11,6 +12,14 @@ log = logging.getLogger("dj-treta")
 
 THINKING_FILE = runtime_path("thinking.log")
 BILLING_FILE = runtime_path("billing.json")
+
+# Serialize the billing read-modify-write. The daemon bills from several threads
+# (being, planner, heartbeat, DJ + direct-call sites), so without this two
+# concurrent updates can lose-update or, across processes, corrupt the JSON
+# (observed: a stale second daemon racing this file produced garbage totals).
+# This guards intra-process races; the cross-process case is handled by not
+# running two daemons (see the restart/zombie note).
+_billing_lock = threading.Lock()
 
 
 def _apply_billing(agent_name: str, inp: int, out: int, cost: float,
@@ -24,25 +33,26 @@ def _apply_billing(agent_name: str, inp: int, out: int, cost: float,
       by_agent{name: {input, output, cost, calls}}, session_start,
       key_spend (optional: gateway's cumulative spend on the key).
     """
-    billing = json.loads(BILLING_FILE.read_text()) if BILLING_FILE.exists() else {
-        "total_input_tokens": 0, "total_output_tokens": 0, "total_cost_usd": 0.0,
-        "calls": 0, "by_agent": {}, "session_start": time.time()
-    }
-    billing["total_input_tokens"] += inp
-    billing["total_output_tokens"] += out
-    billing["calls"] += 1
-    billing["total_cost_usd"] += cost
-    a = billing["by_agent"].setdefault(agent_name, {"input": 0, "output": 0, "cost": 0.0, "calls": 0})
-    a["input"] += inp
-    a["output"] += out
-    a["cost"] += cost
-    a["calls"] += 1
-    if key_spend is not None:
-        # Gateway's authoritative cumulative spend on this key — a cross-check
-        # anchor for the session total (see billing verification).
-        billing["key_spend"] = key_spend
-    BILLING_FILE.write_text(json.dumps(billing, indent=2))
-    return billing
+    with _billing_lock:
+        billing = json.loads(BILLING_FILE.read_text()) if BILLING_FILE.exists() else {
+            "total_input_tokens": 0, "total_output_tokens": 0, "total_cost_usd": 0.0,
+            "calls": 0, "by_agent": {}, "session_start": time.time()
+        }
+        billing["total_input_tokens"] += inp
+        billing["total_output_tokens"] += out
+        billing["calls"] += 1
+        billing["total_cost_usd"] += cost
+        a = billing["by_agent"].setdefault(agent_name, {"input": 0, "output": 0, "cost": 0.0, "calls": 0})
+        a["input"] += inp
+        a["output"] += out
+        a["cost"] += cost
+        a["calls"] += 1
+        if key_spend is not None:
+            # Gateway's authoritative cumulative spend on this key — a cross-check
+            # anchor for the session total (see billing verification).
+            billing["key_spend"] = key_spend
+        BILLING_FILE.write_text(json.dumps(billing, indent=2))
+        return billing
 
 
 def bill_external(agent_name: str, inp: int, out: int, cost: float | None = None) -> None:

--- a/agent/adk_runner.py
+++ b/agent/adk_runner.py
@@ -13,6 +13,57 @@ THINKING_FILE = runtime_path("thinking.log")
 BILLING_FILE = runtime_path("billing.json")
 
 
+def _apply_billing(agent_name: str, inp: int, out: int, cost: float,
+                   key_spend: float | None = None) -> dict:
+    """Read-modify-write the shared billing.json accumulator. The single place
+    the schema is defined, so ADK-path billing (_update_billing) and direct-call
+    billing (bill_external) stay consistent. Returns the updated dict.
+
+    Schema (consumed by TUI + ws_server + session — do not drop fields):
+      total_input_tokens, total_output_tokens, total_cost_usd, calls,
+      by_agent{name: {input, output, cost, calls}}, session_start,
+      key_spend (optional: gateway's cumulative spend on the key).
+    """
+    billing = json.loads(BILLING_FILE.read_text()) if BILLING_FILE.exists() else {
+        "total_input_tokens": 0, "total_output_tokens": 0, "total_cost_usd": 0.0,
+        "calls": 0, "by_agent": {}, "session_start": time.time()
+    }
+    billing["total_input_tokens"] += inp
+    billing["total_output_tokens"] += out
+    billing["calls"] += 1
+    billing["total_cost_usd"] += cost
+    a = billing["by_agent"].setdefault(agent_name, {"input": 0, "output": 0, "cost": 0.0, "calls": 0})
+    a["input"] += inp
+    a["output"] += out
+    a["cost"] += cost
+    a["calls"] += 1
+    if key_spend is not None:
+        # Gateway's authoritative cumulative spend on this key — a cross-check
+        # anchor for the session total (see billing verification).
+        billing["key_spend"] = key_spend
+    BILLING_FILE.write_text(json.dumps(billing, indent=2))
+    return billing
+
+
+def bill_external(agent_name: str, inp: int, out: int, cost: float | None = None) -> None:
+    """Bill an LLM call made OUTSIDE the ADK event loop (direct
+    ``litellm.completion`` sites — canonicalize, mood_resolver, sets, tools/*).
+    Uses the gateway's authoritative ``cost`` when the caller has it, else the
+    per-model rate map. Mirrors into the observability llm_calls row."""
+    try:
+        if cost is None:
+            from . import billing_rates
+            cost = billing_rates.cost_for(billing_rates.alias_for_agent(agent_name), inp, out)
+        _apply_billing(agent_name, inp, out, cost)
+        try:
+            from .observability import record_llm_call
+            record_llm_call(agent=agent_name, input_tokens=inp, output_tokens=out, model_cost=cost)
+        except Exception:
+            pass
+    except Exception:
+        pass
+
+
 class _CorruptionDetector(logging.Handler):
     """Detects 'Missing tool results' warnings from ADK/LiteLLM.
     Sets a flag so the caller can rotate the corrupted session."""
@@ -302,14 +353,21 @@ class ADKRunnerMixin:
                     except Exception:
                         pass
 
-            # Billing — usage_metadata
+            # Billing — usage_metadata. The gateway's authoritative per-call
+            # USD rides on event.custom_metadata['response_cost'] (set by the
+            # conversion wrap in agents.py); use it when present, else a
+            # per-model rate map. candidates_token_count already includes
+            # reasoning tokens — do NOT add thoughts_token_count.
             if event.usage_metadata:
                 um = event.usage_metadata
                 inp = um.prompt_token_count or 0
                 out = um.candidates_token_count or 0
                 if inp > 0 or out > 0:
-                    self._update_billing(agent_name, inp, out)
-                    # v8 Phase 8: record structured llm_calls row
+                    cm = getattr(event, "custom_metadata", None) or {}
+                    auth_cost = cm.get("response_cost")
+                    key_spend = cm.get("key_spend")
+                    cost = self._update_billing(agent_name, inp, out, auth_cost, key_spend)
+                    # v8 Phase 8: record structured llm_calls row (same cost)
                     try:
                         from .observability import record_llm_call
                         tool_calls = []
@@ -321,38 +379,32 @@ class ADKRunnerMixin:
                             input_tokens=inp,
                             output_tokens=out,
                             tool_calls=tool_calls,
+                            model_cost=cost,
                         )
                     except Exception:
                         pass
         except Exception:
             pass
 
-    def _update_billing(self, agent_name: str, inp: int, out: int):
-        """Update billing JSON file with token counts.
+    def _update_billing(self, agent_name: str, inp: int, out: int,
+                        auth_cost: float | None = None, key_spend: float | None = None) -> float:
+        """Accumulate a billed LLM call and broadcast the snapshot to the TUI.
 
-        Also broadcasts a ``billing`` WS event so the TUI can render the cost
-        line without polling the file. The file is still written for offline
-        debugging + future observability tools.
+        Cost priority: the gateway's authoritative ``auth_cost`` (response_cost)
+        when present, else the per-model rate map keyed by the agent's model
+        alias. Returns the cost charged so the caller can share it with the
+        observability row (keeping both totals identical).
         """
         try:
-            billing = json.loads(BILLING_FILE.read_text()) if BILLING_FILE.exists() else {
-                "total_input_tokens": 0, "total_output_tokens": 0, "total_cost_usd": 0.0,
-                "calls": 0, "by_agent": {}, "session_start": time.time()
-            }
-            billing["total_input_tokens"] += inp
-            billing["total_output_tokens"] += out
-            billing["calls"] += 1
-            cost = (inp / 1_000_000 * 0.10) + (out / 1_000_000 * 0.40)
-            billing["total_cost_usd"] += cost
-            if agent_name not in billing["by_agent"]:
-                billing["by_agent"][agent_name] = {"input": 0, "output": 0, "cost": 0.0, "calls": 0}
-            billing["by_agent"][agent_name]["input"] += inp
-            billing["by_agent"][agent_name]["output"] += out
-            billing["by_agent"][agent_name]["cost"] += cost
-            billing["by_agent"][agent_name]["calls"] += 1
-            BILLING_FILE.write_text(json.dumps(billing, indent=2))
+            if auth_cost is not None:
+                cost = float(auth_cost)
+            else:
+                from . import billing_rates
+                cost = billing_rates.cost_for(billing_rates.alias_for_agent(agent_name), inp, out)
+            billing = _apply_billing(agent_name, inp, out, cost, key_spend)
             # Broadcast updated billing snapshot to TUI clients.
             if hasattr(self, '_ws_broadcast'):
                 self._ws_broadcast("billing", billing)
+            return cost
         except Exception:
-            pass
+            return 0.0

--- a/agent/agents.py
+++ b/agent/agents.py
@@ -16,6 +16,49 @@ from google.adk.models.lite_llm import LiteLlm
 from google.adk.tools import FunctionTool, LongRunningFunctionTool
 
 from .config import Config
+
+# ── Cost capture ────────────────────────────────────────────────────────────
+# The gateway (LiteLLM) computes the exact per-call USD and returns it on the
+# litellm response as `_hidden_params['response_cost']`. ADK's own event carries
+# only token counts (its usage_metadata has no cost field), so without this the
+# billing layer can never see the real price and falls back to a flat rate.
+#
+# We wrap the ONE module-level seam ADK uses to convert a litellm response into
+# an ADK LlmResponse — `_model_response_to_generate_content_response` — and stash
+# the authoritative cost (plus the model alias and cumulative key spend) onto
+# `LlmResponse.custom_metadata`. adk_runner._process_event then reads
+# `event.custom_metadata['response_cost']` and bills it verbatim, with automatic
+# per-agent attribution (the event already knows its author). Non-streaming only,
+# which is all DJ Treta uses. No fork, no monkey-patching of the public API.
+import google.adk.models.lite_llm as _adk_litellm
+
+_orig_convert = _adk_litellm._model_response_to_generate_content_response
+
+
+def _convert_with_cost(response, *args, **kwargs):
+    llm_resp = _orig_convert(response, *args, **kwargs)
+    try:
+        hp = getattr(response, "_hidden_params", None) or {}
+        rc = hp.get("response_cost")
+        if rc is not None:
+            md = dict(llm_resp.custom_metadata or {})
+            md["response_cost"] = float(rc)
+            hdrs = hp.get("additional_headers") or {}
+            md["model_group"] = hdrs.get("llm_provider-x-litellm-model-group")
+            ks = hdrs.get("llm_provider-x-litellm-key-spend")
+            if ks is not None:
+                try:
+                    md["key_spend"] = float(ks)
+                except (TypeError, ValueError):
+                    pass
+            llm_resp.custom_metadata = md
+    except Exception:
+        pass
+    return llm_resp
+
+
+_adk_litellm._model_response_to_generate_content_response = _convert_with_cost
+# ────────────────────────────────────────────────────────────────────────────
 from .tools import (
     # Mixer tools (19)
     get_dj_status, get_deck_info, load_track, play_deck, pause_deck,

--- a/agent/billing_rates.py
+++ b/agent/billing_rates.py
@@ -1,0 +1,137 @@
+"""Per-model LLM cost — grounded in the gateway's own numbers.
+
+DJ Treta's cost used to be a flat $0.10/M-in + $0.40/M-out for EVERY agent
+(adk_runner._update_billing), which under-reported the real gateway bill ~21x
+because the Being runs on a pro model and the planner on a flash model at very
+different rates.
+
+This module is the single source of truth for cost. Priority of truth:
+
+  1. The gateway's authoritative per-call ``response_cost`` (LiteLLM computes it
+     and returns it on every response — see agents.py, which rides it onto the
+     ADK event, and ``bill_from_response`` for direct litellm calls). Used
+     verbatim — model-correct and already includes reasoning tokens.
+  2. A per-model rate map fetched once from the gateway's ``/model/info`` at
+     startup (keyed by the SAME alias the agent used, e.g. ``gemini-flash``),
+     used only when (1) isn't available. Verified to reproduce ``response_cost``
+     to the cent.
+  3. A static map (last-known gateway rates) if ``/model/info`` is unreachable.
+
+Unknown aliases are billed 0 with a WARNING — never silently charged flash
+rates (the old bug's failure mode).
+"""
+
+from __future__ import annotations
+
+import logging
+
+log = logging.getLogger("dj-treta")
+
+# Last-known gateway-published rates (USD per token), used only if /model/info
+# is unreachable at startup. Verified live 2026-06-03 against gateway.infrax.ai.
+_STATIC_RATES: dict[str, tuple[float, float]] = {
+    "gemini-flash": (1.5e-6, 9e-6),     # gemini-3.5-flash
+    "gemini-pro":   (2e-6,   1.2e-5),   # gemini-3.1-pro-preview
+    "nano-banana":  (0.0,    0.0),      # image — not token-billed
+}
+
+# Populated by init(); maps alias -> (input_cost_per_token, output_cost_per_token).
+_rates: dict[str, tuple[float, float]] = {}
+
+# Stashed at init() so alias resolution + fallbacks work without threading config
+# through every call site.
+_config = None
+
+
+def init(config) -> None:
+    """Fetch the gateway's per-model rates once at startup and cache them.
+
+    Falls back to the static map on any failure. Idempotent.
+    """
+    global _rates, _config
+    _config = config
+    api_base = (getattr(config.llm, "api_base", "") or "").rstrip("/")
+    api_key = getattr(config.llm, "api_key", "") or ""
+    if not api_base:
+        _rates = dict(_STATIC_RATES)
+        log.warning("billing rates: no api_base — using static map")
+        return
+    try:
+        import httpx
+        headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+        r = httpx.get(f"{api_base}/model/info", headers=headers, timeout=5.0)
+        r.raise_for_status()
+        out: dict[str, tuple[float, float]] = {}
+        for m in (r.json().get("data") or []):
+            name = m.get("model_name")
+            info = m.get("model_info") or {}
+            ci = info.get("input_cost_per_token")
+            co = info.get("output_cost_per_token")
+            if name and ci is not None and co is not None:
+                out[name] = (float(ci), float(co))
+        _rates = out or dict(_STATIC_RATES)
+        log.info("billing rates loaded from gateway: %s", dict(_rates))
+    except Exception as e:
+        _rates = dict(_STATIC_RATES)
+        log.warning("billing rates: /model/info unreachable (%s) — using static map", e)
+
+
+def _strip_prefix(model_str: str) -> str:
+    """`openai/gemini-flash` / `vertex_ai/gemini-3.5-flash` -> bare alias."""
+    return (model_str or "").split("/", 1)[-1]
+
+
+def alias_for_agent(agent_name: str) -> str:
+    """Resolve which model alias an ADK agent used, from config.
+
+    The Being ("treta") runs on ``being_model``; every other agent (dj_treta,
+    planner, library_manager, producer, mixer, consciousness) runs on ``model``.
+    """
+    if _config is None:
+        return ""
+    llm = _config.llm
+    model = llm.being_model if agent_name == "treta" else llm.model
+    return _strip_prefix(model or llm.model)
+
+
+def cost_for(alias: str, inp: int, out: int) -> float:
+    """USD for `inp` input + `out` output tokens at the gateway's rate for `alias`.
+
+    Returns 0.0 (with a WARNING) for an unknown alias — never silently applies a
+    default rate.
+    """
+    rates = _rates or _STATIC_RATES
+    rate = rates.get(alias)
+    if rate is None:
+        log.warning("billing: unknown model alias %r — cost left 0 (not defaulting to flash)", alias)
+        return 0.0
+    ci, co = rate
+    return inp * ci + out * co
+
+
+def response_cost_of(resp) -> float | None:
+    """Extract the gateway's authoritative per-call USD from a raw litellm
+    response (``_hidden_params['response_cost']``). None if absent."""
+    try:
+        hp = getattr(resp, "_hidden_params", None) or {}
+        rc = hp.get("response_cost")
+        return float(rc) if rc is not None else None
+    except Exception:
+        return None
+
+
+def bill_from_response(resp, agent_name: str) -> None:
+    """Bill a DIRECT ``litellm.completion(...)`` response (call sites that don't
+    flow through the ADK event loop) into the shared billing accumulator, using
+    the gateway's authoritative ``response_cost`` when present."""
+    try:
+        cost = response_cost_of(resp)
+        u = getattr(resp, "usage", None)
+        inp = int(getattr(u, "prompt_tokens", 0) or 0)
+        out = int(getattr(u, "completion_tokens", 0) or 0)
+        if inp == 0 and out == 0 and cost is None:
+            return
+        from .adk_runner import bill_external
+        bill_external(agent_name, inp, out, cost)
+    except Exception:
+        pass

--- a/agent/canonicalize.py
+++ b/agent/canonicalize.py
@@ -113,6 +113,8 @@ Now return JSON for the input above."""
             api_base=cfg.llm.api_base, api_key=cfg.llm.api_key,
             temperature=0.1, timeout=15,
         )
+        from .billing_rates import bill_from_response
+        bill_from_response(resp, "library")
         raw = resp.choices[0].message.content.strip()
         if "```" in raw:
             raw = raw.split("```", 2)[1]
@@ -211,6 +213,8 @@ def genre_matches(artist: str, title: str, genre: str,
             api_base=cfg.llm.api_base, api_key=cfg.llm.api_key,
             temperature=0.0, timeout=12,
         )
+        from .billing_rates import bill_from_response
+        bill_from_response(resp, "library")
         raw = resp.choices[0].message.content.strip()
         if "```" in raw:
             raw = raw.split("```", 2)[1]

--- a/agent/main.py
+++ b/agent/main.py
@@ -530,6 +530,14 @@ class DJTretaBeing(
         _ensure_litellm(self.config)
         _ensure_mixxx(self.config)
 
+        # Load per-model cost rates from the gateway so billing reflects the
+        # ACTUAL price of each model used (pro vs flash), not a flat rate.
+        try:
+            from . import billing_rates
+            billing_rates.init(self.config)
+        except Exception as _e:
+            log.warning(f"billing rates init failed: {_e}")
+
         # Reset rate on both decks — clears any leftover offsets from previous session
         try:
             url = self.config.mixxx.url

--- a/agent/mood_resolver.py
+++ b/agent/mood_resolver.py
@@ -214,6 +214,8 @@ Return JSON for the input above."""
             api_base=cfg.llm.api_base, api_key=cfg.llm.api_key,
             temperature=0.1, timeout=15,
         )
+        from .billing_rates import bill_from_response
+        bill_from_response(resp, "dj_treta")
         text = resp.choices[0].message.content.strip()
         if "```" in text:
             text = text.split("```", 2)[1]

--- a/agent/observability.py
+++ b/agent/observability.py
@@ -17,12 +17,6 @@ from typing import Optional
 
 log = logging.getLogger("dj-treta")
 
-# Approx cost per token (Gemini Flash 3). v8 uses these for the billing
-# counter; v9 will swap for a per-model table.
-_COST_PER_INPUT_TOKEN = 0.00000025  # $0.25 per 1M
-_COST_PER_OUTPUT_TOKEN = 0.00000100  # $1.00 per 1M
-
-
 def record_llm_call(
     agent: str,
     instruction: str = "",
@@ -31,10 +25,23 @@ def record_llm_call(
     latency_ms: int = 0,
     tool_calls: Optional[list] = None,
     error: str = "",
+    model_cost: Optional[float] = None,
 ) -> float:
-    """Insert an llm_calls row. Returns the computed cost_usd."""
-    cost = (input_tokens * _COST_PER_INPUT_TOKEN
-            + output_tokens * _COST_PER_OUTPUT_TOKEN)
+    """Insert an llm_calls row. Returns the cost_usd recorded.
+
+    Cost source: the caller's authoritative ``model_cost`` (the gateway's
+    per-call USD) when provided, else the per-model rate map keyed by the
+    agent's model alias. Never the old flat per-token constants — those
+    diverged from billing.json and under-reported the real gateway bill.
+    """
+    if model_cost is not None:
+        cost = float(model_cost)
+    else:
+        try:
+            from .billing_rates import cost_for, alias_for_agent
+            cost = cost_for(alias_for_agent(agent), input_tokens, output_tokens)
+        except Exception:
+            cost = 0.0
     try:
         from .db import get_db
         db = get_db()

--- a/agent/sets.py
+++ b/agent/sets.py
@@ -44,6 +44,8 @@ class SetsMixin:
                     api_base=cfg.llm.api_base, api_key=cfg.llm.api_key,
                     temperature=0.9, timeout=10,
                 )
+                from .billing_rates import bill_from_response
+                bill_from_response(resp, "dj_treta")
                 title = resp.choices[0].message.content.strip()[:50]
             except Exception:
                 title = f"Set #{set_number}"

--- a/agent/tools/discovery.py
+++ b/agent/tools/discovery.py
@@ -222,6 +222,8 @@ def _enrich_track(filepath: Path, genre: str, yt_meta: dict = None):
                 api_base=cfg.llm.api_base, api_key=cfg.llm.api_key,
                 temperature=0.5, timeout=15,
             )
+            from ..billing_rates import bill_from_response
+            bill_from_response(resp, "library")
             raw = resp.choices[0].message.content.strip()
             if "```" in raw:
                 raw = raw.split("```")[1].split("```")[0].strip()

--- a/agent/tools/generation.py
+++ b/agent/tools/generation.py
@@ -156,6 +156,8 @@ def generate_track(prompt: str, bpm: int = 128, key: str = "C minor",
                 api_base=cfg.llm.api_base, api_key=cfg.llm.api_key,
                 temperature=0.9, timeout=10,
             )
+            from ..billing_rates import bill_from_response
+            bill_from_response(_name_resp, "producer")
             track_name = _name_resp.choices[0].message.content.strip().strip('"\'')[:50]
             track_name = re.sub(r'[<>:"/\\|?*]', '', track_name).strip()
         except Exception:
@@ -180,6 +182,8 @@ def generate_track(prompt: str, bpm: int = 128, key: str = "C minor",
             api_base=cfg.llm.api_base, api_key=cfg.llm.api_key,
             temperature=0.5, timeout=10,
         )
+        from ..billing_rates import bill_from_response
+        bill_from_response(_mood_resp, "producer")
         _raw = _mood_resp.choices[0].message.content.strip()
         if "```" in _raw:
             _raw = _raw.split("```")[1].split("```")[0].strip()

--- a/agent/tools/perception.py
+++ b/agent/tools/perception.py
@@ -100,6 +100,8 @@ def hear_music(deck: int = 0, duration: int = 10) -> str:
             temperature=0.5,
             timeout=30,
         )
+        from ..billing_rates import bill_from_response
+        bill_from_response(resp, "dj_treta")
         return resp.choices[0].message.content.strip()
     except Exception as e:
         return f"Gemini audio error: {e}"
@@ -224,6 +226,8 @@ def analyze_track(track_path: str) -> str:
             temperature=0.3,
             timeout=60,
         )
+        from ..billing_rates import bill_from_response
+        bill_from_response(resp, "dj_treta")
 
         raw = resp.choices[0].message.content.strip()
 
@@ -388,6 +392,8 @@ def preview_track(track_path: str, position: int = 30, duration: int = 10) -> st
             temperature=0.5,
             timeout=30,
         )
+        from ..billing_rates import bill_from_response
+        bill_from_response(resp, "dj_treta")
         return resp.choices[0].message.content.strip()
     except Exception as e:
         return f"Preview error: {e}"

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -1,0 +1,124 @@
+"""Tests for per-model cost accounting (agent.billing_rates + the ADK cost wrap).
+
+Grounds the 2026-06-03 fix that replaced a flat $0.10/$0.40-per-M rate with the
+gateway's authoritative per-model pricing.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent import billing_rates as br
+
+
+@pytest.fixture(autouse=True)
+def _isolate_rates():
+    """Snapshot/restore module globals so tests don't leak state."""
+    saved_rates, saved_config = dict(br._rates), br._config
+    yield
+    br._rates, br._config = saved_rates, saved_config
+
+
+def _fake_config(api_base="http://127.0.0.1:1/unreachable", api_key="sk-test"):
+    return SimpleNamespace(llm=SimpleNamespace(
+        api_base=api_base, api_key=api_key,
+        model="openai/gemini-flash", being_model="openai/gemini-pro"))
+
+
+class TestRates:
+
+    def test_static_fallback_when_unreachable(self):
+        # Bad api_base → init falls back to the static map, doesn't raise.
+        br.init(_fake_config())
+        assert br._rates == br._STATIC_RATES
+        # flash input rate, 1M tokens = $1.50
+        assert abs(br.cost_for("gemini-flash", 1_000_000, 0) - 1.5) < 1e-9
+
+    def test_cost_for_per_model(self):
+        br._rates = dict(br._STATIC_RATES)
+        # flash: 1M in @1.5 + 1M out @9 = 10.5
+        assert abs(br.cost_for("gemini-flash", 1_000_000, 1_000_000) - 10.5) < 1e-9
+        # pro: 1M in @2 + 1M out @12 = 14.0
+        assert abs(br.cost_for("gemini-pro", 1_000_000, 1_000_000) - 14.0) < 1e-9
+
+    def test_unknown_alias_returns_zero_not_flash(self):
+        br._rates = dict(br._STATIC_RATES)
+        # The old bug silently applied a default rate; now unknown → 0.
+        assert br.cost_for("does-not-exist", 1_000_000, 1_000_000) == 0.0
+
+    def test_alias_for_agent_from_config(self):
+        br._config = _fake_config().__class__(  # reuse namespace shape
+            llm=SimpleNamespace(model="openai/gemini-flash", being_model="openai/gemini-pro"))
+        assert br.alias_for_agent("treta") == "gemini-pro"
+        for a in ("dj_treta", "planner", "library_manager", "producer", "mixer", "consciousness"):
+            assert br.alias_for_agent(a) == "gemini-flash"
+
+    def test_rates_parsed_from_model_info(self, monkeypatch):
+        payload = {"data": [
+            {"model_name": "gemini-flash", "model_info": {
+                "input_cost_per_token": 1.5e-6, "output_cost_per_token": 9e-6}},
+            {"model_name": "gemini-pro", "model_info": {
+                "input_cost_per_token": 2e-6, "output_cost_per_token": 1.2e-5}},
+        ]}
+
+        class _Resp:
+            def raise_for_status(self): pass
+            def json(self): return payload
+
+        import httpx
+        monkeypatch.setattr(httpx, "get", lambda *a, **k: _Resp())
+        br.init(_fake_config(api_base="https://gw.example"))
+        assert br._rates["gemini-flash"] == (1.5e-6, 9e-6)
+        assert br._rates["gemini-pro"] == (2e-6, 1.2e-5)
+
+
+class TestResponseCostExtraction:
+
+    def test_response_cost_of(self):
+        resp = SimpleNamespace(_hidden_params={"response_cost": 0.007186})
+        assert br.response_cost_of(resp) == 0.007186
+
+    def test_response_cost_of_absent(self):
+        assert br.response_cost_of(SimpleNamespace(_hidden_params={})) is None
+        assert br.response_cost_of(SimpleNamespace()) is None
+
+
+class TestAdkCostWrap:
+
+    def test_convert_with_cost_stashes_response_cost(self):
+        # The agents.py wrap must copy _hidden_params['response_cost'] onto the
+        # LlmResponse.custom_metadata so _process_event can bill it.
+        import agent.agents as agents
+        from google.adk.models.llm_response import LlmResponse
+
+        base = LlmResponse(custom_metadata={"existing": 1})
+        # Stub the original converter to return our base response.
+        orig = agents._orig_convert
+        try:
+            agents._orig_convert = lambda response, *a, **k: base
+            fake_litellm_resp = SimpleNamespace(_hidden_params={
+                "response_cost": 0.00301,
+                "additional_headers": {
+                    "llm_provider-x-litellm-model-group": "gemini-pro",
+                    "llm_provider-x-litellm-key-spend": "1.95",
+                },
+            })
+            out = agents._convert_with_cost(fake_litellm_resp)
+            assert out.custom_metadata["response_cost"] == 0.00301
+            assert out.custom_metadata["model_group"] == "gemini-pro"
+            assert out.custom_metadata["key_spend"] == 1.95
+            assert out.custom_metadata["existing"] == 1  # preserved
+        finally:
+            agents._orig_convert = orig
+
+    def test_convert_with_cost_no_cost_is_safe(self):
+        import agent.agents as agents
+        from google.adk.models.llm_response import LlmResponse
+        base = LlmResponse()
+        orig = agents._orig_convert
+        try:
+            agents._orig_convert = lambda response, *a, **k: base
+            out = agents._convert_with_cost(SimpleNamespace(_hidden_params={}))
+            assert (out.custom_metadata or {}).get("response_cost") is None
+        finally:
+            agents._orig_convert = orig

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -14,7 +14,19 @@ from agent.observability import (
 
 class TestRecordLLMCall:
 
+    @pytest.fixture(autouse=True)
+    def _billing_rates(self):
+        """Configure per-model rates so the fallback path (no model_cost) resolves
+        to gateway flash/pro rates instead of $0/unknown-alias."""
+        from types import SimpleNamespace
+        from agent import billing_rates as br
+        br._rates = dict(br._STATIC_RATES)
+        br._config = SimpleNamespace(
+            llm=SimpleNamespace(model="openai/gemini-flash", being_model="openai/gemini-pro"))
+        yield
+
     def test_insert_creates_row(self, test_db):
+        # Authoritative gateway cost is passed through verbatim.
         cost = record_llm_call(
             agent="planner",
             instruction="plan something deep",
@@ -22,8 +34,9 @@ class TestRecordLLMCall:
             output_tokens=200,
             latency_ms=1500,
             tool_calls=[{"name": "list_library_tracks", "args": "{}"}],
+            model_cost=0.30409,
         )
-        assert cost > 0.0
+        assert cost == 0.30409
 
         from agent.db import get_db
         db = get_db()
@@ -33,21 +46,28 @@ class TestRecordLLMCall:
             assert row["input_tokens"] == 1000
             assert row["output_tokens"] == 200
             assert row["latency_ms"] == 1500
-            assert row["cost_usd"] > 0
+            assert abs(row["cost_usd"] - 0.30409) < 1e-9
         finally:
             db.close()
 
-    def test_cost_computation(self, test_db):
-        # 1M input + 1M output tokens → roughly $1.25
+    def test_cost_computation_uses_per_model_rate(self, test_db):
+        # No model_cost → falls back to the per-model rate map. dj_treta is a
+        # subagent → flash ($1.5/M in, $9/M out): 1M+1M = $10.50 (NOT the old
+        # flat ~$1.25 — that flat rate was the bug).
         cost = record_llm_call(
             agent="dj_treta",
             input_tokens=1_000_000,
             output_tokens=1_000_000,
         )
-        assert 1.0 <= cost <= 2.0
+        assert abs(cost - 10.5) < 1e-6
+
+    def test_authoritative_cost_overrides_ratemap(self, test_db):
+        cost = record_llm_call(agent="dj_treta", input_tokens=1_000_000,
+                               output_tokens=1_000_000, model_cost=0.42)
+        assert cost == 0.42
 
     def test_zero_tokens_still_records(self, test_db):
-        cost = record_llm_call(agent="being", input_tokens=0, output_tokens=0)
+        cost = record_llm_call(agent="dj_treta", input_tokens=0, output_tokens=0)
         assert cost == 0.0
 
 


### PR DESCRIPTION
## Problem

DJ Treta's displayed cost was a **flat \$0.10/M-in + \$0.40/M-out for every agent** (`adk_runner._update_billing`). But the Being runs on a **pro** model and the planner/DJ on a **flash** model, billed by the gateway at very different rates. Measured result: her displayed cost **under-reported the real gateway bill ~21×**. A second, *different* flat rate (\$0.25/\$1.00) lived in `observability.py`, so the SQLite `llm_calls` total and `billing.json` total also diverged.

## Fix — bill each call by the model it actually used, using the gateway's own numbers

Verified live against `gateway.infrax.ai`:
- The gateway returns the authoritative per-call cost on every response (`_hidden_params['response_cost']`), and publishes per-model rates at `/model/info` keyed by the same alias the agent uses.
- Per-call recompute reproduces `response_cost` **to the cent**; a clean single-daemon session matched the gateway's `key_spend` delta within rounding (**101.8%**, was ~5%).

### Changes
- **`agent/billing_rates.py` (new)** — single source of truth. `init()` fetches per-model rates from `/model/info` at startup; `cost_for()` prices tokens; `alias_for_agent()` resolves `treta→being_model`, others→`model` from config. Unknown alias → `0` with a WARNING (never silently defaults to flash). `bill_from_response()` bills direct litellm calls. Static fallback if `/model/info` is unreachable.
- **`agent/agents.py`** — wrap the one ADK conversion seam (`_model_response_to_generate_content_response`) to ride the gateway's `response_cost` (+ `model_group`, `key_spend`) onto `LlmResponse.custom_metadata`, so `_process_event` bills it verbatim with automatic per-agent attribution. Non-streaming only (all DJ Treta uses). No fork.
- **`agent/adk_runner.py`** — `_update_billing` prefers the authoritative cost, else the per-model rate map; returns the cost so observability records the identical number. Shared `_apply_billing()` accumulator + module-level `bill_external()` for direct sites. `candidates_token_count` already includes reasoning tokens (not double-counted).
- **`agent/observability.py`** — `record_llm_call(model_cost=…)`; old flat per-token constants removed.
- **`agent/main.py`** — `billing_rates.init(config)` at startup.
- **Direct `litellm.completion` sites** now bill via `bill_from_response`: canonicalize, mood_resolver, sets, tools/{generation,perception,discovery}. (Off-gateway Vertex calls — Lyria, `text-embedding-005` — remain out of scope; they bypass the gateway and have no gateway rate.)

## Tests
- New `tests/test_billing.py` (rate map == gateway, unknown-alias→0, alias resolution, response_cost extraction, the ADK cost wrap) + `test_observability` updated for per-model rates. **20/20 pass.**
- Full suite: **107 failed / 390 passed** vs base **108 / 379** — this PR *removes* one failure and adds passing tests; **zero new failures**. The remaining failures are pre-existing integration tests that need a live daemon/LLM (identical on base).

## Verification
Clean single-daemon 180s window: gateway Δ \$0.10390 vs billing Δ \$0.10581 → **101.8% captured** (gap +\$0.0019, timing noise).

## Out of scope (separate findings, flagged to maintainers)
- `djtreta restart` can leave a **zombie daemon** (orphaned PID file → two daemons double-billing the gateway). This polluted early measurements; not a billing bug.
- The vestigial local-LiteLLM watchdog probes the remote gateway's `/health` every ~2 min — noisy, should use `/health/liveliness` or be skipped for a remote gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)